### PR TITLE
Added submod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/rplidar_ros"]
+	path = src/rplidar_ros
+	url = https://github.com/robopeak/rplidar_ros


### PR DESCRIPTION
Could not find fork that allowed PWM control, conflicting information about the PWM onboard.

* In `~/catkin_lidar` this repo exists, adding it to the repo should make organizing easier
Same code, new place.