### PR TITLE
recover lost sim node, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,17 @@ and set the ROS_MASTER_URI to the robot's computer IP address:
 	export ROS_IP=X.Y.Z.2
 	export ROS_MASTER_URI=http://X.Y.Z.1:11311
 
-# Testing
-Launch `fakeOdom` or `flakeOdom` first for testing, it will provide
-networktables data in place of the rio data and will simulate changing encoder
-values. The tidalforceodom node will generate /odom and when pointed toward
-127.0.0.1 it will read the fake data from the encoders
+# Running the Code
+
+To run everything on the real robot (laser drivers, odometry, URDF):
+
+	export ROS_IP=10.17.21.106
+	roslaunch hungry_toaster hungry_toaster.launch
+
+To simuate network tables for odometry:
+
+	rosrun tidalforce_odom simulated_rio.py
+
+To just view the URDF/meshes:
+
+	roslaunch hungry_toaster view_urdf.launch

--- a/tidalforce_odom/src/simulated_rio.py
+++ b/tidalforce_odom/src/simulated_rio.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import time
+from math import sin, cos
+from networktables import NetworkTables
+
+import logging	# Required
+logging.basicConfig(level=logging.DEBUG)
+
+NetworkTables.initialize()
+table = NetworkTables.getTable("SmartDashboard")
+
+fakePortEncoder = 10
+fakeStarboardEncoder = 10
+speedModifier = 1000
+i = 1
+while 1:
+    table.putNumber("Port", fakePortEncoder)
+    table.putNumber("Starboard", fakeStarboardEncoder)
+
+    fakePortEncoder = round(speedModifier * (i + (sin(i) + sin(3 * i) + sin(9 * i)))) # Seperate so we can adjust them individually
+    fakeStarboardEncoder = round(speedModifier * (i + (sin(i) + sin(3 * i) + sin(9 * i))))
+    time.sleep(0.05)
+    i = i + 0.005
+
+    if i >= 10:
+        i = 1


### PR DESCRIPTION
During the directory refactor we lost the simulated network tables node -- brought it back for safe keeping. Also updated the README for the new launch files